### PR TITLE
[PROOFS] Fix minor typo: septic means putrid. 

### DIFF
--- a/Lecture/4_proof.tex
+++ b/Lecture/4_proof.tex
@@ -154,7 +154,7 @@
   \concept{Conclusion: never trust ``obviously correct'' algorithms}
 \end{frame}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
-\begin{frame}{Other try to convince septics: \alert{you test it}}
+\begin{frame}{Other try to convince skeptics: \alert{you test it}}
   \begin{block}{Issues} 
     \begin{itemize}
     \item a \textit{whole} load of arrays exists out there. Cannot test them
@@ -249,7 +249,7 @@
    \end{itemize}
  \end{block}
   
- \begin{block}{To convince real septics, you have to \textbf{prove} correctness}
+ \begin{block}{To convince real skeptics, you have to \textbf{prove} correctness}
    \begin{itemize}
    \item And you cannot do that without a proper specification (at least)
    \end{itemize}


### PR DESCRIPTION
We want to convince skeptics. It doesn't matter if they are putrid, dirty or infected. Or does it? :)

I used the American spelling `skeptics` (as opposed to GB `sceptics`) because as far as I can see US spelling is what is used throughout the document.
